### PR TITLE
Remove dead code

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "noFallthroughCasesInSwitch": true,
     "sourceMap": true,
     "outDir": "dist",
-    "baseUrl": ".",
     "paths": {
       "*": ["node_modules/*"]
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,5 @@
     },
     "typeRoots": ["node_modules/@types"]
   },
-  "include": ["src/**/*"],
-  "files": ["./typings/module-less.d.ts"]
+  "include": ["src/**/*.ts"]
 }

--- a/typings/module-less.d.ts
+++ b/typings/module-less.d.ts
@@ -1,7 +1,0 @@
-declare module '*.module.less' {
-  const styles: {
-    readonly [key: string]: string
-  }
-
-  export default styles
-}


### PR DESCRIPTION
Nuff said. Module-less object types are autogenerated so typings are not needed anymore.