### PR TITLE
Revert css-module typings error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,6 @@
     },
     "typeRoots": ["node_modules/@types"]
   },
-  "include": ["src/**/*"]
+  "include": ["./src/**/*"],
+  "files": ["./types/module-less.d.ts"]
 }

--- a/types/module-less.d.ts
+++ b/types/module-less.d.ts
@@ -1,0 +1,7 @@
+declare module '*.module.less' {
+  const styles: {
+    readonly [key: string]: string
+  }
+
+  export default styles
+}


### PR DESCRIPTION
There is a bug that in `typings-for-css-modules-loader` that causes the ts-loader to compile the project before the types are compiled. This file is actually needed for production builds to pass.